### PR TITLE
32 Proxmox API Errors

### DIFF
--- a/APIServer.go
+++ b/APIServer.go
@@ -514,7 +514,16 @@ func (a *APIServer) updateFormation(w http.ResponseWriter, r *http.Request) {
 		a.respondWithError(w)
 		return
 	}
-	a.respondWithJSON(w, http.StatusCreated, as)
+	a.respondOKWithJson(w, RESTFormation{
+		FlightID: formation.FlightID,
+		Name: formation.Name,
+		CPU: formation.CPU,
+		RAM: formation.RAM,
+		Disk: formation.Disk,
+		BaseName: formation.BaseName,
+		Domain: formation.Domain,
+		TargetCount: as.TargetCount,
+	})
 }
 
 func (a *APIServer) deleteFormation(w http.ResponseWriter, r *http.Request) {

--- a/Formation.go
+++ b/Formation.go
@@ -63,7 +63,7 @@ func (f *Formation) performHealthChecks(db *gorm.DB) error {
 				Num: f.getNextNum(i),
 				FormationID: int(f.ID),
 			}
-			result := db.Save(newPlane)
+			result := db.Save(&newPlane)
 			if result.Error != nil {
 				return fmt.Errorf("unable to update formation with new planes with error: %w", result.Error)
 			}

--- a/Formation.go
+++ b/Formation.go
@@ -59,13 +59,15 @@ func (f *Formation) performHealthChecks(db *gorm.DB) error {
 		var offset = f.TargetCount - len(f.Planes)
 		// TODO: Generate unique names for new planes.
 		for i := 0; i < offset; i++ {
-			f.Planes = append(f.Planes, Plane{
+			newPlane := Plane{
 				Num: f.getNextNum(i),
-			})
-		}
-		result := db.Save(f)
-		if result.Error != nil {
-			return fmt.Errorf("unable to update formation with new planes with error: %w", result.Error)
+				FormationID: int(f.ID),
+			}
+			result := db.Save(newPlane)
+			if result.Error != nil {
+				return fmt.Errorf("unable to update formation with new planes with error: %w", result.Error)
+			}
+			f.Planes = append(f.Planes, newPlane)
 		}
 	}
 

--- a/Plane.go
+++ b/Plane.go
@@ -48,7 +48,7 @@ func (p *Plane) BeforeCreate(tx *gorm.DB) error {
 	if err != nil {
 		return fmt.Errorf("unable to create plane: %w", err)
 	}
-	result := tx.First(p.Formation, p.FormationID)
+	result := tx.First(&p.Formation, p.FormationID)
 	if result.Error != nil {
 		return fmt.Errorf("unable to get formation ID %d for new plane: %w", p.FormationID, err)
 	}

--- a/Plane.go
+++ b/Plane.go
@@ -48,6 +48,14 @@ func (p *Plane) BeforeCreate(tx *gorm.DB) error {
 	if err != nil {
 		return fmt.Errorf("unable to create plane: %w", err)
 	}
+	result := tx.First(p.Formation, p.FormationID)
+	if result.Error != nil {
+		return fmt.Errorf("unable to get formation ID %d for new plane: %w", p.FormationID, err)
+	}
+	err = p.Formation.Validate()
+	if err != nil {
+		return fmt.Errorf("invalid formation configuration for plane: %w", err)
+	}
 	err = p.buildPlane(tx)
 	if err != nil {
 		// TODO: Should detect what kind of error occurred

--- a/ProxmoxAdapter.go
+++ b/ProxmoxAdapter.go
@@ -40,6 +40,7 @@ func ProxmoxBuildLxc(db *gorm.DB, client *proxmox.Client, p *Plane) error {
 	config.Nameserver = defaults.Network.Nameservers
 	config.Networks = proxmox.QemuDevices{
 		0 : {
+			"name": "eth0",
 			"bridge": defaults.Proxmox.PublicNetwork,
 			"ip": "10.1.0.200/16",
 			"gw": defaults.Network.Gateway,

--- a/ProxmoxAdapter.go
+++ b/ProxmoxAdapter.go
@@ -70,10 +70,6 @@ func ProxmoxBuildLxc(db *gorm.DB, client *proxmox.Client, p *Plane) error {
 		return fmt.Errorf("unable to create LXC container with error: %w", err)
 	}
 	p.ProxmoxIdentifier = vmr.VmId()
-	result := db.Save(p)
-	if result.Error != nil {
-		return fmt.Errorf("unable to save new VMID of plane in DB: %w", err)
-	}
 	return nil
 }
 

--- a/ProxmoxAdapter.go
+++ b/ProxmoxAdapter.go
@@ -85,7 +85,10 @@ func ProxmoxDestroyLxc(client *proxmox.Client, p *Plane) error {
 		return fmt.Errorf("unable to stop LXC container: %w", err)
 	}
 	time.Sleep(10 * time.Second)
-	_, err = proxmoxOverrideDeleteVmParams(client, vmr, nil)
+	_, err = proxmoxOverrideDeleteVmParams(client, vmr, map[string]interface{}{
+		"force": 1,
+		"purge": 1,
+	})
 	if err != nil {
 		return fmt.Errorf("unable to delete LXC container for plane %s: %w", p.getFQDN(), err)
 	}
@@ -98,6 +101,8 @@ func proxmoxOverrideDeleteVmParams(c *proxmox.Client, vmr *proxmox.VmRef, params
 		return "", err
 	}
 	fmt.Printf("VMR TYPE: %s", vmr.GetVmType())
+	fmt.Printf("VMR ID: %d", vmr.VmId())
+	fmt.Printf("VMR NODE: %s", vmr.Node())
 	reqBody := proxmox.ParamsToBody(params)
 	url := fmt.Sprintf("/nodes/%s/%s/%d", vmr.Node(), vmr.GetVmType(), vmr.VmId())
 	var taskResponse map[string]interface{}

--- a/ProxmoxAdapter.go
+++ b/ProxmoxAdapter.go
@@ -43,7 +43,7 @@ func ProxmoxBuildLxc(db *gorm.DB, client *proxmox.Client, p *Plane) error {
 			"bridge": defaults.Proxmox.PublicNetwork,
 			"ip": "10.1.0.200/16",
 			"gw": defaults.Network.Gateway,
-			"fw": "0",
+			"firewall": "0",
 			"mtu": defaults.Network.MTU,
 		},
 	}

--- a/ProxmoxAdapter.go
+++ b/ProxmoxAdapter.go
@@ -116,7 +116,7 @@ func proxmoxOverrideDeleteVmParams(c *proxmox.Client, vmr *proxmox.VmRef, params
 	if err != nil {
 		return "", fmt.Errorf("INTERNAL ERROR: %w", err)
 	}
-	resp, err := session.RequestJSON("DELETE", url, nil, nil, &reqBody, &taskResponse)
+	resp, err := session.RequestJSON("DELETE", url, nil, nil, nil, &taskResponse)
 	if err != nil {
 		return "", fmt.Errorf("INTERNAL ERROR: %w", err)
 	}


### PR DESCRIPTION
Fixed an issue with the 3rd party library where an invalid DELETE payload was being sent whenever an LXC container was to be deleted. Also fixed an issue where a PUT request on `/formation/:id` returned an uninitialized `RESTFormation` object.