### PR TITLE
Application versioning

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,10 +23,10 @@ jobs:
       run: sudo mkdir /etc/captain && sudo chmod 777 /etc/captain
 
     - name: Build
-      run: go build -v ./...
+      run: make build
 
     - name: Test
-      run: go test -v -coverprofile=cover.out ./...
+      run: make test
 
     - name: Publish code coverage
       uses: paambaati/codeclimate-action@v2.7.5

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ builder/conf/*.key
 builder/conf/*.private
 *.env
 .idea/*
+
+cover.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `CHANGELOG.md`.
 - Added security policy in `SECURITY.md`.
+- Added automated versioning to compiled output.
 
 ### Security
 - Defined security policy to provide security patches for latest patch version of the latest minor release.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+BINARY=captain
+VERSION=`git describe --tags`
+LDFLAGS=-ldflags="-w -s -X main.Version=${VERSION}"
+
+build:
+	go build -v ${LDFLAGS} -o ${BINARY} ./...
+
+test:
+	go test -v -coverprofile=cover.out ./...

--- a/main.go
+++ b/main.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"os"
+)
+
+var (
+	Version string
 )
 
 // Main entry point of the application. Handles the creation of the requested number of workers for each task, and sets
@@ -18,7 +23,7 @@ func main() {
 	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	// TODO: Read verbosity level from command line args
 
-	log.Info().Msg("Captain v0.0.0 is starting up")
+	log.Info().Msg(fmt.Sprintf("Captain %s is starting up", getApplicationVersion()))
 
 	if *bootstrapOnly {
 		err := BootstrapCluster()
@@ -41,4 +46,10 @@ func main() {
 		log.Fatal().Stack().Err(err).Msg("Captain has fatally crashed")
 		return
 	}
+}
+
+// There is a bug in how 'go test' is implemented. This method does not
+// have a unit test.
+func getApplicationVersion() string {
+	return Version
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-package main_test
+package main
 
 import "testing"
 


### PR DESCRIPTION
- Added makefile-based build system
- Added versioning to file output

No unit tests because of an issue with how `go test` is implemented with `LDFLAGS`.

Closes #53