### PR TITLE
#39 Per-driver image configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ builder/conf/*.private
 
 cover.out
 
-test.db
+testing.db
+db/test.db
 dev.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A dummy provider driver is now available for testing purposes.
   Helps with simulating the Captain stack without modifying a live
   hypervisor environment.
+  
+### Changed
+
+- Image mappings can now be made on a per-driver basis in `config.yaml`.
 
 ### Removed
 

--- a/ImageStore/ImageStore.go
+++ b/ImageStore/ImageStore.go
@@ -1,0 +1,16 @@
+package ImageStore
+
+import (
+	"fmt"
+	"github.com/spf13/viper"
+)
+
+func GetProviderSpecificImageConfiguration(driverYamlTag string, imagetype string) (string, error) {
+	if !viper.IsSet(fmt.Sprintf("config.images.%s", imagetype)) {
+		return "", fmt.Errorf("image type %s is not configured in config.yaml", imagetype)
+	}
+	if !viper.IsSet(fmt.Sprintf("config.images.%s.%s", imagetype, driverYamlTag)) {
+		return "", fmt.Errorf("image type %s not found from driver %s in config.yaml", imagetype, driverYamlTag)
+	}
+	return viper.GetString(fmt.Sprintf("config.images.%s.%s", imagetype, driverYamlTag)), nil
+}

--- a/ImageStore/ImageStore.go
+++ b/ImageStore/ImageStore.go
@@ -5,6 +5,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+// GetProviderSpecificImageConfiguration maps a generic OS name to a storage path that will be accepted
+// by the selected provider driver using its reported YAML tag.
 func GetProviderSpecificImageConfiguration(driverYamlTag string, imagetype string) (string, error) {
 	if !viper.IsSet(fmt.Sprintf("config.images.%s", imagetype)) {
 		return "", fmt.Errorf("image type %s is not configured in config.yaml", imagetype)

--- a/ImageStore/ImageStore_test.go
+++ b/ImageStore/ImageStore_test.go
@@ -1,0 +1,49 @@
+package ImageStore
+
+import (
+	"fmt"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestGetProviderSpecificImageConfigurationDummy(t *testing.T) {
+	require.NoError(t, helperSetupConfigFile("config_dummy_only.yaml"))
+	path, err := GetProviderSpecificImageConfiguration("dummy", "debian-10")
+	assert.NoError(t, err)
+	assert.Equal(t, "notrealpath", path)
+}
+
+func TestGetProviderSpecificImageConfigurationDummyBadPath(t *testing.T) {
+	require.NoError(t, helperSetupConfigFile("config_dummy_only.yaml"))
+	path, err := GetProviderSpecificImageConfiguration("dummy", "fakeos")
+	assert.Error(t, err)
+	assert.Equal(t, "", path)
+}
+
+func TestGetProviderSpecificImageConfigurationDummyBadDriver(t *testing.T) {
+	require.NoError(t, helperSetupConfigFile("config_dummy_only.yaml"))
+	path, err := GetProviderSpecificImageConfiguration("notrealdriver", "debian-10")
+	assert.Error(t, err)
+	assert.Equal(t, "", path)
+}
+
+func helperSetupConfigFile(configFile string) error {
+	viper.Reset()
+	_ = os.Remove("/etc/captain/config.yaml")
+	input, err := ioutil.ReadFile(fmt.Sprintf("../testing/%s", configFile))
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile("/etc/captain/config.yaml", input, 0644)
+	if err != nil {
+		return err
+	}
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath("/etc/captain")
+	return viper.ReadInConfig()
+}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ First a bit of terminology. The highest level in Captain is called an *airspace*
 
 Each airspace has many *flights*. A flight is a complete app, which may include a reverse proxy, a database, and a web server. Each of those services is a *formation*. A formation is a collection of planes (usually containers or VMs) that can be seamlessly scaled up and down.
 
-At the preset moment, the only way to provision planes is to manually edit the Sqlite3 or PostgreSQL database. In the near future it will be possible to provision airspaces, flights, and formations using a REST API, a CLI, or a GraphQL interface. Planes are usually not managed directly by the API, and instead are automatically managed by Captain depending on how the formation is configured.
+To modify the state database to trigger builds in Proxmox, you may use a tool like Curl, or the CLI tool
+(migrating to this repo soon).
 
 # Contributing
 

--- a/drivers/ProviderDriverManager.go
+++ b/drivers/ProviderDriverManager.go
@@ -20,6 +20,7 @@ func BuildPlaneOnAnyProvider(p *providers.GenericPlane) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to initialize %s driver: %w", driver.GetYAMLTag(), err)
 	}
+
 	cuid, err := driver.BuildPlane(p)
 	if err != nil {
 		return "", fmt.Errorf("unable to build plane with driver %s: %w", driver.GetYAMLTag(), err)

--- a/drivers/providers/ProxmoxLxcProviderDriver.go
+++ b/drivers/providers/ProxmoxLxcProviderDriver.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/ARMmaster17/Captain/ImageStore"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/spf13/viper"
 	"net/http"
@@ -27,7 +28,11 @@ func (d ProxmoxLxcProviderDriver) Connect() error {
 // the container for provisioning.
 func (d ProxmoxLxcProviderDriver) BuildPlane(p *GenericPlane) (string, error) {
 	config := proxmox.NewConfigLxc()
-	config.Ostemplate = viper.GetString(d.getConfigItemPath("image"))
+	template, err := ImageStore.GetProviderSpecificImageConfiguration(d.GetYAMLTag(), viper.GetString("defaults.image"))
+	if err != nil {
+		return "", err
+	}
+	config.Ostemplate = template
 	config.Arch = "amd64"
 	config.CMode = "tty"
 	config.Console = true

--- a/main.go
+++ b/main.go
@@ -77,11 +77,12 @@ func generateConfigFile() error {
 	viper.Set("defaults.network.searchdomain", "")
 	viper.Set("defaults.network.gateway", "10.1.0.1")
 	viper.Set("defaults.network.mtu", 1450)
+	viper.Set("defaults.image", "debian-10")
 	// In the future when there is more than one driver, this section should not
 	// be added automatically.
 	viper.Set("config.drivers.provisioners", []string{"proxmoxlxc"})
 	viper.Set("config.api.port", 5000)
-	viper.Set("drivers.provisioners.proxmoxlxc.image", "pve-img:vztmpl/debian-10-standard_10.7-1_amd64.tar.gz")
+	viper.Set("images.debian-10.proxmoxlxc", "pve-img:vztmpl/debian-10-standard_10.7-1_amd64.tar.gz")
 	viper.Set("drivers.provisioners.proxmoxlxc.publicnetwork", "internal")
 	viper.Set("drivers.provisioners.proxmoxlxc.diskstorage", "pve-storage")
 	viper.Set("drivers.provisioners.proxmoxlxc.defaultnode", "pxvh1")

--- a/testing/config_dummy_only.yaml
+++ b/testing/config_dummy_only.yaml
@@ -5,9 +5,13 @@ defaults:
     searchdomain: ""
     gateway: 10.1.0.1
     mtu: 1450
+  image: debian-10
 config:
   drivers:
     provisioners:
       - dummy
   api:
     port: 5000
+  images:
+    debian-10:
+      dummy: notrealpath


### PR DESCRIPTION
# New PR

## PR Checklist

Check the following boxes once you have completed them.
All boxes must be checked for a PR to be reviewed.

- [x] New code has unit tests (if PR includes code changes).
- [x] Code has been tested locally and passes all tests.
- [x] All submitted code has been documented in-line where needed.
- [x] `CHANGELOG.md` has been updated for user-facing changes.

## Changes

Added an `ImageStore` module where the path of an image file is determined using a generic image name, and at build time when a driver is selected this image value will be mapped to a path that is supported by the underlying provider driver (if one has been provided by the user in `config.yaml`).

## Related Issues

Closes #39