### PR TITLE
#156 Fix for nil session object

### DIFF
--- a/ATC/drivers/ProviderDriverManager.go
+++ b/ATC/drivers/ProviderDriverManager.go
@@ -75,7 +75,7 @@ func getDestroyDriver(cuid string) (providers.ProviderDriver, error) {
 func driverLookupByYAMLTag(driverentry string) (providers.ProviderDriver, error) {
 	if driverentry == (&providers.ProxmoxLxcProviderDriver{}).GetYAMLTag() {
 		// In the future there could be a check here to see if a driver is ready to receive new planes.
-		return providers.ProxmoxLxcProviderDriver{}, nil
+		return &providers.ProxmoxLxcProviderDriver{}, nil
 	}
 	if driverentry == (&providers.DummyProviderDriver{}).GetYAMLTag() {
 		return providers.DummyProviderDriver{}, nil
@@ -87,7 +87,7 @@ func driverLookupByYAMLTag(driverentry string) (providers.ProviderDriver, error)
 func driverLookupByCUIDPrefix(cuidprefix string) (providers.ProviderDriver, error) {
 	if cuidprefix == (&providers.ProxmoxLxcProviderDriver{}).GetCUIDPrefix() {
 		// In the future there could be a check here to see if a driver is ready to receive new planes.
-		return providers.ProxmoxLxcProviderDriver{}, nil
+		return &providers.ProxmoxLxcProviderDriver{}, nil
 	}
 	if cuidprefix == (&providers.DummyProviderDriver{}).GetCUIDPrefix() {
 		return providers.DummyProviderDriver{}, nil

--- a/ATC/drivers/providers/ProxmoxLxcProviderDriver.go
+++ b/ATC/drivers/providers/ProxmoxLxcProviderDriver.go
@@ -18,7 +18,7 @@ type ProxmoxLxcProviderDriver struct {
 
 // Connect reads any Proxmox connection parameters defined in the environment and performs authentication with the
 // designated Proxmox cluster.
-func (d ProxmoxLxcProviderDriver) Connect() error {
+func (d *ProxmoxLxcProviderDriver) Connect() error {
 	tlsConf := &tls.Config{InsecureSkipVerify: !viper.GetBool(d.getConfigItemPath("forcessl"))}
 	d.client, _ = proxmox.NewClient(viper.GetString(d.getConfigItemPath("url")), nil, tlsConf, 300)
 	return d.client.Login(os.Getenv("CAPTAIN_PROXMOX_USER"), os.Getenv("CAPTAIN_PROXMOX_PASSWORD"), "")
@@ -26,7 +26,7 @@ func (d ProxmoxLxcProviderDriver) Connect() error {
 
 // BuildPlane converts the given GenericPlane into a data structure that is usable by the Proxmox API and submits
 // the container for provisioning.
-func (d ProxmoxLxcProviderDriver) BuildPlane(p *GenericPlane) (string, error) {
+func (d *ProxmoxLxcProviderDriver) BuildPlane(p *GenericPlane) (string, error) {
 	config := proxmox.NewConfigLxc()
 	template, err := imagestore.GetProviderSpecificImageConfiguration(d.GetYAMLTag(), viper.GetString("defaults.image"))
 	if err != nil {
@@ -78,7 +78,7 @@ func (d ProxmoxLxcProviderDriver) BuildPlane(p *GenericPlane) (string, error) {
 }
 
 // DestroyPlane will destroy a plane that is managed by the Proxmox LXC driver.
-func (d ProxmoxLxcProviderDriver) DestroyPlane(cuid string, p *GenericPlane) error {
+func (d *ProxmoxLxcProviderDriver) DestroyPlane(cuid string, p *GenericPlane) error {
 	vmr, err := d.client.GetVmRefByName(p.FQDN)
 	if err != nil {
 		return fmt.Errorf("unable to obtain reference to underlying LXC container for plane %s:\n%w", p.FQDN, err)
@@ -96,24 +96,24 @@ func (d ProxmoxLxcProviderDriver) DestroyPlane(cuid string, p *GenericPlane) err
 
 // GetCUIDPrefix gets the prefix that should be added to the beginning of the CUID strings for all planes that are
 // managed by this driver.
-func (d ProxmoxLxcProviderDriver) GetCUIDPrefix() string {
+func (d *ProxmoxLxcProviderDriver) GetCUIDPrefix() string {
 	return "proxmox.lxc"
 }
 
 // GetYAMLTag gets the YAML tag that the Proxmox LXC driver uses to identify settings unique to this driver
 // in config.yaml.
-func (d ProxmoxLxcProviderDriver) GetYAMLTag() string {
+func (d *ProxmoxLxcProviderDriver) GetYAMLTag() string {
 	return "proxmoxlxc"
 }
 
 // getFullYAMLTag gets the base YAML tag for all settings that are unique to the Proxmox LXC driver.
-func (d ProxmoxLxcProviderDriver) getFullYAMLTag() string {
+func (d *ProxmoxLxcProviderDriver) getFullYAMLTag() string {
 	return fmt.Sprintf("drivers.provisioners.%s", d.GetYAMLTag())
 }
 
 // getConfigItemPath returns the full YAML path to a configuration file for the Proxmox LXC driver with the given tag(s) appended
 // at the end.
-func (d ProxmoxLxcProviderDriver) getConfigItemPath(entryPath string) string {
+func (d *ProxmoxLxcProviderDriver) getConfigItemPath(entryPath string) string {
 	return fmt.Sprintf("%s.%s", d.getFullYAMLTag(), entryPath)
 }
 


### PR DESCRIPTION
# New PR

## PR Checklist

Check the following boxes once you have completed them.
All boxes must be checked for a PR to be reviewed.

- [x] New code has unit tests (if PR includes code changes).
- [x] Code has been tested locally and passes all tests.
- [x] All submitted code has been documented in-line where needed.
- [x] `CHANGELOG.md` has been updated for user-facing changes.

## Changes

Doesn't really fix #156, but these changes bring the Proxmox provider driver in line with the style of the other code files.

## Related Issues

Related to #156